### PR TITLE
Update plxMyBetterUrls.php pour php 8.2

### DIFF
--- a/plxMyBetterUrls.php
+++ b/plxMyBetterUrls.php
@@ -13,6 +13,12 @@ class plxMyBetterUrls extends plxPlugin {
 	 * @return	stdio
 	 * @author	Stephane F
 	 **/
+
+	public $article;
+	public $category;
+	public $static;
+	public $lang;
+	
 	public function __construct($default_lang) {
 
 		# appel du constructeur de la classe plxPlugin (obligatoire)


### PR DESCRIPTION
Déclaration préalable des strings pour éviter les warnings suivant avec php 8.2 :

2472268#0: *43775 FastCGI sent in stderr: "PHP message: PHP Deprecated: Creation of dynamic property plxMyBetterUrls::$article is deprecated in /var/www/vhosts/txori.com/txori/data/plugins/plxMyBetterUrls/plxMyBetterUrls.php on line 25; PHP message: PHP Deprecated: Creation of dynamic property plxMyBetterUrls::$category is deprecated in /var/www/vhosts/txori.com/txori/data/plugins/plxMyBetterUrls/plxMyBetterUrls.php on line 26; PHP message: PHP Deprecated: Creation of dynamic property plxMyBetterUrls::$static is deprecated in /var/www/vhosts/txori.com/txori/data/plugins/plxMyBetterUrls/plxMyBetterUrls.php on line 27" while reading response header from upstream

2472268#0: *44248 FastCGI sent in stderr: "PHP message: PHP Deprecated: Creation of dynamic property plxMyBetterUrls::$lang is deprecated in /var/www/vhosts/txori.com/txori/data/plugins/plxMyBetterUrls/plxMyBetterUrls.php on line 94" while reading response header from upstream